### PR TITLE
Check if Application has valid name in filter fn

### DIFF
--- a/src/gnome_abrt/views.py
+++ b/src/gnome_abrt/views.py
@@ -47,9 +47,14 @@ def problems_filter(model, itrtr, data):
                 if val and pattern in val:
                     return True
 
-        return (item_match(pattern, problem)
-                or pattern in problem['application'].name
-                or pattern in problem.problem_id)
+        if item_match(pattern, problem) or pattern in problem.problem_id:
+            return True
+
+        app = problem['application']
+        if app is None or app.name is None:
+            return False
+
+        return pattern in app.name
 
     pattern = data.current_pattern
 


### PR DESCRIPTION
The bug was introduced in commits closing #26. Before #26 Application name was never None, if name was unknown, "N/A" string was used instead of None.

Closes rhbz#1009189

Signed-off-by: Jakub Filak jfilak@redhat.com
