### PR TITLE
Use human readable type string everywhere

### DIFF
--- a/src/gnome_abrt/problems.py
+++ b/src/gnome_abrt/problems.py
@@ -177,6 +177,8 @@ class Problem(object):
             return self.is_reported()
         elif item == 'submission':
             return self.get_submission()
+        elif item == 'human_type':
+            return self.get_human_type()
 
         if cached and item in self.data:
             retval = self.data[item]
@@ -219,6 +221,13 @@ class Problem(object):
 
     def is_reported(self):
         return not self['reported_to'] is None
+
+    def get_human_type(self):
+        typ = self['type']
+        if typ == "CCpp":
+            return "C/C++"
+
+        return typ
 
     def assure_ownership(self):
         return self.source.chown_problem(self.problem_id)

--- a/src/gnome_abrt/views.py
+++ b/src/gnome_abrt/views.py
@@ -92,13 +92,10 @@ def problem_to_storage_values(problem):
 
     if app.name:
         name = app.name
-        typ = problem['type']
+        typ = problem['human_type']
     else:
-        name = problem['type']
+        name = problem['human_type']
         typ = ""
-
-    if typ == "CCpp":
-        typ = "C/C++"
 
     return ["{0!s}\n{1!s}".format(smart_truncate(name, length=40), typ),
             "{0!s}\n{1!s}".format(fancydate(problem['date_last']),
@@ -653,7 +650,7 @@ class OopsWindow(Gtk.ApplicationWindow):
                 # If Application's name is unknown, display neutral
                 # header "'Type' problem has been detected":
                 #  Kerneloops problem has been detected
-                #  CCpp problem has been detected
+                #  C/C++ problem has been detected
                 #  Python problem has been detected
                 #  Ruby problem has been detected
                 #  VMCore problem has been detected
@@ -661,7 +658,7 @@ class OopsWindow(Gtk.ApplicationWindow):
                 #  Java problem has been detected
                 self._builder.lbl_reason.set_text(
                         _("{0} problem has been detected").format(
-                                problem['type']))
+                                problem['human_type']))
 
             self._builder.lbl_app_version_value.set_text(
                         problem['package'] or _("N/A"))


### PR DESCRIPTION
Richard Marko rmarko@redhat.com came up with a great idea of using
human readable type strings instead of confusing machine strings.

He has implemented his idea in the patch adding conversion of 'CCpp' to
'C/C++' in the list of problems. But there is another place where we
want to display this kind of string.

This commit extends Richard's commit[1] a bit.

1: 237654ca7f1d6fbb95690e9f8c56b2d6891d4f96

Signed-off-by: Jakub Filak jfilak@redhat.com
