### PR TITLE
Rename desktop launcher to "Problem Reporting"

### DIFF
--- a/src/gnome-abrt.desktop.in
+++ b/src/gnome-abrt.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-_Name=Automatic Bug Reporting Tool
+_Name=Problem Reporting
 _Comment=View and report application crashes
 Icon=gnome-abrt
 Exec=gnome-abrt


### PR DESCRIPTION
"Problem Reporting" is shorter, simpler (easier to understand) and won't be elipsized by the shell.

This fixes issue #53
