### PR TITLE
Make the border between the panes thinner

### DIFF
--- a/src/gnome_abrt/oops.glade
+++ b/src/gnome_abrt/oops.glade
@@ -203,7 +203,7 @@
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
                     <property name="hscrollbar_policy">never</property>
-                    <property name="shadow_type">in</property>
+                    <property name="shadow_type">none</property>
                     <property name="min_content_width">300</property>
                     <child>
                       <object class="GtkTreeView" id="tv_problems">


### PR DESCRIPTION
Make the border between the panes thinner. It looks nicer and a little closer to the mockup (but we still have a long way to go).
