### PR TITLE
Don't use key-press-event on the search entry

### DIFF
--- a/src/gnome_abrt/oops.glade
+++ b/src/gnome_abrt/oops.glade
@@ -160,7 +160,6 @@
                 <property name="primary_icon_name">edit-find-symbolic</property>
                 <property name="primary_icon_activatable">False</property>
                 <property name="primary_icon_sensitive">False</property>
-                <signal name="key-press-event" handler="on_se_problems_key_press_event" swapped="no"/>
                 <signal name="search-changed" handler="on_se_problems_search_changed" swapped="no"/>
               </object>
               <packing>


### PR DESCRIPTION
Using search-changed only means that there's a slight delay (150ms) between the user's
keystrokes and the actual filtering, which makes the search much more responsive.
