### PR TITLE
Fix warning with empty search results

### DIFF
--- a/src/gnome_abrt/views.py
+++ b/src/gnome_abrt/views.py
@@ -48,7 +48,8 @@ def problems_filter(model, itrtr, data):
             for i in ['component', 'reason',
                         'executable', 'package']:
                 # pattern is 'ascii' and problem[i] is 'dbus.String'
-                val = problem[i].encode('utf-8')
+                if problem[i]:
+                    val = problem[i].encode('utf-8')
                 if val and pattern in val:
                     return True
 


### PR DESCRIPTION
Traceback (most recent call last):
File "/home/hadess/Projects/gnome-install/lib64/python2.7/site-packages/gnome_abrt/views.py", line 69, in problems_filter
  return match_pattern(pattern, model[itrtr][2])
File "/home/hadess/Projects/gnome-install/lib64/python2.7/site-packages/gnome_abrt/views.py", line 55, in match_pattern
  if item_match(pattern, problem) or pattern in problem.problem_id:
File "/home/hadess/Projects/gnome-install/lib64/python2.7/site-packages/gnome_abrt/views.py", line 51, in item_match
  val = problem[i].encode('utf-8')
AttributeError: 'NoneType' object has no attribute 'encode'
