### PR TITLE
Add symbolic icon

### DIFF
--- a/icons/Makefile.am
+++ b/icons/Makefile.am
@@ -13,17 +13,18 @@ private_icons = \
 		hicolor_status_256x256_gnome-abrt.png
 		$(NULL)
 
-public_icons = hicolor_apps_16x16_gnome-abrt.png	\
-		hicolor_apps_22x22_gnome-abrt.png	\
-		hicolor_apps_24x24_gnome-abrt.png	\
-		hicolor_apps_32x32_gnome-abrt.png	\
-		hicolor_apps_48x48_gnome-abrt.png	\
-		hicolor_apps_256x256_gnome-abrt.png	\
-		hicolor_status_16x16_gnome-abrt.png	\
-		hicolor_status_22x22_gnome-abrt.png	\
-		hicolor_status_24x24_gnome-abrt.png	\
-		hicolor_status_32x32_gnome-abrt.png	\
-		hicolor_status_48x48_gnome-abrt.png	\
+public_icons = hicolor_apps_16x16_gnome-abrt.png		\
+		hicolor_apps_22x22_gnome-abrt.png		\
+		hicolor_apps_24x24_gnome-abrt.png		\
+		hicolor_apps_32x32_gnome-abrt.png		\
+		hicolor_apps_48x48_gnome-abrt.png		\
+		hicolor_apps_256x256_gnome-abrt.png		\
+		hicolor_apps_symbolic_gnome-abrt-symbolic.svg	\
+		hicolor_status_16x16_gnome-abrt.png		\
+		hicolor_status_22x22_gnome-abrt.png		\
+		hicolor_status_24x24_gnome-abrt.png		\
+		hicolor_status_32x32_gnome-abrt.png		\
+		hicolor_status_48x48_gnome-abrt.png		\
 		hicolor_status_256x256_gnome-abrt.png
 		$(NULL)
 

--- a/icons/hicolor_apps_symbolic_gnome-abrt-symbolic.svg
+++ b/icons/hicolor_apps_symbolic_gnome-abrt-symbolic.svg
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='gnome-abrt-symbolic.svg' height='16' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' inkscape:version='0.48.4 r9939' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata90'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer9' inkscape:cx='335.51828' inkscape:cy='88.026479' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#555753' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='true' inkscape:snap-grids='true' inkscape:snap-nodes='true' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1381' inkscape:window-maximized='1' inkscape:window-width='2560' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
+    <inkscape:grid empspacing='2' enabled='true' id='grid4866' originx='138px' originy='108px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  </sodipodi:namedview>
+  <title id='title9167'>Gnome Symbolic Icon Theme</title>
+  <defs id='defs7386'/>
+  <g inkscape:groupmode='layer' id='layer9' inkscape:label='apps' style='display:inline' transform='translate(-103.0002,-325)'>
+
+    <path inkscape:connector-curvature='0' d='m 108.34395,327 c -0.74444,0 -1.26707,0.60327 -1.34375,1.34375 l -1,9.65625 0.28125,0 9.4375,0 0.28125,0 -1,-9.65625 C 114.92352,327.60327 114.40089,327 113.65645,327 l -5.3125,0 z m 2.625,1.03125 c 0.54448,-0.0172 1.04849,0.48677 1.03125,1.03125 l 0,3.9375 c 0.007,0.52831 -0.47163,1 -1,1 -0.52836,0 -1.00747,-0.47169 -1,-1 l 0,-3.9375 c -0.008,-0.4666 0.3541,-0.91253 0.8125,-1 0.0511,-0.0145 0.10345,-0.0249 0.15625,-0.0312 z M 110.0002,335 l 2,0 0,2 -2,0 0,-2 z' id='rect11265' style='fill:#bebebe;fill-opacity:1;stroke:none'/>
+    <rect height='1' id='rect11269' rx='0.5' ry='0.5' style='fill:#bebebe;fill-opacity:1;stroke:none' transform='scale(1,-1)' width='12.000002' x='105.0002' y='-340'/>
+  </g>
+</svg>


### PR DESCRIPTION
Hi, can you please add this symbolic icon? It's needed for the application menu in Fedora 22.

Sorry for the super-late, post-beta notice, but we're just now getting on top of this. :(