### PR TITLE
Use own window header also in GNOME Classic

### DIFF
--- a/src/gnome_abrt/desktop.py
+++ b/src/gnome_abrt/desktop.py
@@ -20,4 +20,5 @@
 import os
 
 def replace_window_header():
-    return os.environ.get('XDG_CURRENT_DESKTOP') in ['GNOME']
+    return os.environ.get('XDG_CURRENT_DESKTOP') in \
+                        ['GNOME', 'GNOME-Classic:GNOME', 'GNOME-Classic']


### PR DESCRIPTION
Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>