### PR TITLE
Use C implementation of test function which tests a presence of Xserver

### DIFF
--- a/src/gnome-abrt
+++ b/src/gnome-abrt
@@ -24,21 +24,13 @@ import logging
 import signal
 import locale
 from argparse import ArgumentParser
+from gnome_abrt.wrappers import (show_events_list_dialog,
+                                 show_system_config_abrt_dialog,
+                                 can_connect_to_xserver)
 
-from ctypes import cdll, util
-
-XLIB_PATH = util.find_library('X11')
-if not XLIB_PATH:
-    sys.stderr.write("Could not load X11 library\n")
-    sys.exit(1)
-
-XLIB = cdll.LoadLibrary(XLIB_PATH)
-DISPLAY = XLIB.XOpenDisplay(None)
-if DISPLAY == 0:
+if not can_connect_to_xserver():
     sys.stderr.write("Cannot connect to X server\n")
-    sys.exit(2)
-
-XLIB.XCloseDisplay(DISPLAY)
+    sys.exit(1)
 
 # pygobject
 #pylint: disable=E0611
@@ -62,8 +54,6 @@ from gnome_abrt.dbus_problems import (get_standard_problems_source,
                                       get_foreign_problems_source)
 from gnome_abrt.errors import UnavailableSource
 from gnome_abrt.l10n import _
-from gnome_abrt.wrappers import (show_events_list_dialog,
-                                 show_system_config_abrt_dialog)
 from gnome_abrt.config import get_configuration
 from gnome_abrt.dialogs import show_report_problem_with_abrt
 from gnome_abrt.url.gliburltitle import (GetURLTitleSourcePool,

--- a/src/gnome_abrt/wrappers/Makefile.am
+++ b/src/gnome_abrt/wrappers/Makefile.am
@@ -9,6 +9,7 @@ _wrappers_la_SOURCES = \
     configure.c \
     problem_details.c \
     problem_app.c \
+    xserver_check.c \
     common.h
 
 _wrappers_la_CPPFLAGS = \

--- a/src/gnome_abrt/wrappers/__init__.py
+++ b/src/gnome_abrt/wrappers/__init__.py
@@ -20,4 +20,5 @@ from gnome_abrt.wrappers._wrappers import (show_events_list_dialog,
                                            show_system_config_abrt_dialog,
                                            show_problem_details_for_dir,
                                            get_app_for_cmdline,
-                                           get_app_for_env)
+                                           get_app_for_env,
+                                           can_connect_to_xserver)

--- a/src/gnome_abrt/wrappers/module.c
+++ b/src/gnome_abrt/wrappers/module.c
@@ -28,6 +28,7 @@ static PyMethodDef module_methods[] = {
     { "show_problem_details_for_dir", p_show_problem_details_for_dir, METH_VARARGS, "Open a dialog with technical details" },
     { "get_app_for_cmdline", p_get_app_for_cmdline, METH_VARARGS, "Get the application for a specific command-line" },
     { "get_app_for_env", p_get_app_for_env, METH_VARARGS, "Get the application for a specific environment" },
+    { "can_connect_to_xserver", p_can_connect_to_xserver, METH_VARARGS, "Testing whether it is possible to connect to the X server" },
     { NULL }
 };
 

--- a/src/gnome_abrt/wrappers/xserver_check.c
+++ b/src/gnome_abrt/wrappers/xserver_check.c
@@ -1,6 +1,6 @@
 /*
-    Copyright (C) 2012  Abrt team.
-    Copyright (C) 2012  RedHat inc.
+    Copyright (C) 2015  Abrt team.
+    Copyright (C) 2015  RedHat inc.
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -16,20 +16,22 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Suite 500, Boston, MA  02110-1335  USA
 */
-#include <Python.h>
+#include <common.h>
+#include <libreport/problem_utils.h>
+#include <pygobject.h>
+#include <X11/Xlib.h>
 
-/* module-level functions */
-PyObject *p_show_events_list_dialog(PyObject *module, PyObject *args);
-PyObject *p_show_system_config_abrt_dialog(PyObject *module, PyObject *args);
+PyObject *p_can_connect_to_xserver(PyObject *module, PyObject *args)
+{
+    (void)module;
+    (void)args;
 
-/* Problem Details */
-PyObject *p_show_problem_details_for_dir(PyObject *module, PyObject *args);
+    Display *d = XOpenDisplay(NULL);
+    if (d == NULL)
+        Py_RETURN_FALSE;
 
-/* App for a command-line */
-PyObject *p_get_app_for_cmdline(PyObject *module, PyObject *args);
+    XCloseDisplay(d);
 
-/* App for an env */
-PyObject *p_get_app_for_env(PyObject *module, PyObject *args);
+    Py_RETURN_TRUE;
+}
 
-/* Testing whether it is possible to connect to the X server */
-PyObject *p_can_connect_to_xserver(PyObject *module, PyObject *args);


### PR DESCRIPTION
Replace Python implementation of the test function with C implementation.
We should not use libX11 through "cdll.LoadLibrary()".

Related to rhbz#1188002

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>