### PR TITLE
Don't scroll the sidebar horizontally

### DIFF
--- a/src/gnome_abrt/oops.glade
+++ b/src/gnome_abrt/oops.glade
@@ -294,6 +294,8 @@
                       <object class="GtkScrolledWindow" id="scrolledwindow1">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="hscrollbar_policy">never</property>
+                        <property name="vscrollbar_policy">automatic</property>
                         <child>
                           <object class="GtkViewport" id="viewport1">
                             <property name="visible">True</property>

--- a/src/gnome_abrt/views.py
+++ b/src/gnome_abrt/views.py
@@ -33,6 +33,8 @@ from gi.repository import Gdk
 from gi.repository import GObject
 #pylint: disable=E0611
 from gi.repository import Gio
+#pylint: disable=E0611
+from gi.repository import Pango
 
 import gnome_abrt.problems as problems
 import gnome_abrt.config as config
@@ -221,13 +223,14 @@ class ProblemListBoxCell(Gtk.Box):
 
         self._problem = problem_values[3]
 
-        self._hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
+        self._hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 12)
 
         self._lbl_app = Gtk.Label.new(problem_values[0])
-        self._lbl_app.set_use_markup(True)
-        self._lbl_app.set_markup("<b>{0}</b>".format(problem_values[0]))
-
         self._lbl_app.set_halign(Gtk.Align.START)
+        self._lbl_app.set_alignment(0.0, 0.5)
+        self._lbl_app.set_ellipsize(Pango.EllipsizeMode.END)
+        self._lbl_app.set_width_chars(15)
+        self._lbl_app.get_style_context().add_class('app-name-label')
 
         self._lbl_date = Gtk.Label.new(problem_values[1])
         self._lbl_date.set_halign(Gtk.Align.END)
@@ -422,6 +425,9 @@ class OopsWindow(Gtk.ApplicationWindow):
         css_prv = Gtk.CssProvider.new()
         css_prv.load_from_data("GtkListBoxRow {\n"
                                "  padding          : 12px;\n"
+                               "}\n"
+                               ".app-name-label {\n"
+                               "  font-weight      : bold;\n"
                                "}\n"
                                ".oops-reason {\n"
                                "  font-size        : 120%;\n"


### PR DESCRIPTION
This pull request intentionally consists of two commits so you may choose to cherry-pick one or both of them:
* b13b911 does what it should do: does not allow the sidebar to scroll horizontally and adds some more minor UI tweaks to make the sidebar look good when it can't scroll horizontally,
* 0976fa6 enhances the UI: if the application name is too long wraps it and tries to display in two lines before ellipsizing.
A hint for testing: use the GtkInspector and change the crashed application name to check how it looks when it is too long, also check what happens when it is too long but can't be wrapped naturally because it consists of one long word.

Closes #119.