### PR TITLE
trivial: set spacing=6 in box_header for non-GNOME desktops

### DIFF
--- a/src/gnome_abrt/oops.glade
+++ b/src/gnome_abrt/oops.glade
@@ -150,6 +150,7 @@
           <object class="GtkBox" id="box_header">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="spacing">6</property>
             <child>
               <object class="GtkStackSwitcher" id="box_sources_switcher">
                 <property name="visible">True</property>


### PR DESCRIPTION
This is the same spacing as in `GtkHeaderBar` in GNOME. Otherwise the
Report and Details buttons look bad in non-GNOME desktop environment.

You can test this issue also in GNOME with this command:

`XDG_CURRENT_DESKTOP=whateverstringbutnotGNOME gnome-abrt`

this will fool gnome-abrt that it is not running in GNOME and should not
use the `GtkHeaderBar`.

I don't file an issue, I think it is not worth.