### PR TITLE
HTMLParseError replaced with generic Exception

### DIFF
--- a/src/gnome_abrt/url/urltitle.py
+++ b/src/gnome_abrt/url/urltitle.py
@@ -21,7 +21,7 @@ import sys
 import threading
 import logging
 from urllib.request import urlopen
-from html.parser import HTMLParser, HTMLParseError
+from html.parser import HTMLParser
 
 
 def get_url_title(url):
@@ -85,7 +85,7 @@ class HTMLTitleGetter(HTMLParser):
         tgt = HTMLTitleGetter()
         try:
             tgt.feed(data)
-        except HTMLParseError as ex:
+        except Exception as ex:
             logging.debug("{1} ('{0}')".format(data, str(ex)))
             # Hopefully title is parsed correctly
 


### PR DESCRIPTION
HTMLParseError raises a DeprecationWarning in Python 3.4 and it has been removed in Python 3.5.
https://hg.python.org/cpython/file/3.4/Lib/html/parser.py#l171