### PR TITLE
Fix the plural/singular translations for fancydate

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -286,31 +286,58 @@ msgstr "Sense origen"
 msgid "Not found in cache but deleted: {0}"
 msgstr "No s'ha trobat en la memòria cau però s'ha eliminat: {0}"
 
-#: ../src/gnome_abrt/tools.py:34
+#: ../src/gnome_abrt/tools.py:42
 msgid "Future"
 msgstr "Futur"
 
-#: ../src/gnome_abrt/tools.py:41
+#: ../src/gnome_abrt/tools.py:49
 msgid "Yesterday"
 msgstr "Ahir"
 
-#: ../src/gnome_abrt/tools.py:50
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:63
+#, fuzzy
 msgid "Last week"
+msgstr "La darrera setmana"
+
+#. Translators: This message will never be used for less than
+#. 2 weeks ago nor for more than one month ago. However, the singular
+#. form is necessary for some languages which do not have plural.
+#: ../src/gnome_abrt/tools.py:67
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} week ago"
 msgid_plural "{0:d} weeks ago"
 msgstr[0] "La darrera setmana"
 msgstr[1] "Fa {0:d} setmanes"
 
-#: ../src/gnome_abrt/tools.py:53
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:72
+#, fuzzy
 msgid "Last month"
+msgstr "El darrer mes"
+
+#. Translators: This message will never be used for less than
+#. 2 months ago nor for more than one year ago. See the comment above.
+#: ../src/gnome_abrt/tools.py:75
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} month ago"
 msgid_plural "{0:d} months ago"
 msgstr[0] "El darrer mes"
 msgstr[1] "Fa {0:d} mesos"
 
-#: ../src/gnome_abrt/tools.py:56
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:80
+#, fuzzy
 msgid "Last year"
+msgstr "El darrer any"
+
+#. Translators: This message will never be used for less than
+#. 2 years ago. However, the singular form is necessary for some
+#. languages which do not have plural (Chinese, Japanese, Korean)
+#. or reuse the singular form for some plural cases (21 in Russian).
+#: ../src/gnome_abrt/tools.py:85
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} year ago"
 msgid_plural "{0:d} years ago"
 msgstr[0] "El darrer any"
 msgstr[1] "Fa {0:d} anys"

--- a/po/cs.po
+++ b/po/cs.po
@@ -279,33 +279,60 @@ msgstr "Žádný zdroj"
 msgid "Not found in cache but deleted: {0}"
 msgstr "Nenalzeno ve vyrovnávací paměti ale smazáno: {0}"
 
-#: ../src/gnome_abrt/tools.py:34
+#: ../src/gnome_abrt/tools.py:42
 msgid "Future"
 msgstr "Budoucnost"
 
-#: ../src/gnome_abrt/tools.py:41
+#: ../src/gnome_abrt/tools.py:49
 msgid "Yesterday"
 msgstr "Včera"
 
-#: ../src/gnome_abrt/tools.py:50
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:63
+#, fuzzy
 msgid "Last week"
+msgstr "Minulý týden"
+
+#. Translators: This message will never be used for less than
+#. 2 weeks ago nor for more than one month ago. However, the singular
+#. form is necessary for some languages which do not have plural.
+#: ../src/gnome_abrt/tools.py:67
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} week ago"
 msgid_plural "{0:d} weeks ago"
 msgstr[0] "Minulý týden"
 msgstr[1] "Před {0:d} týdny"
 msgstr[2] "Před {0:d} týdny"
 
-#: ../src/gnome_abrt/tools.py:53
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:72
+#, fuzzy
 msgid "Last month"
+msgstr "Minulý měsíc"
+
+#. Translators: This message will never be used for less than
+#. 2 months ago nor for more than one year ago. See the comment above.
+#: ../src/gnome_abrt/tools.py:75
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} month ago"
 msgid_plural "{0:d} months ago"
 msgstr[0] "Minulý měsíc"
 msgstr[1] "Před {0:d} měsíci"
 msgstr[2] "Před {0:d} měsíci"
 
-#: ../src/gnome_abrt/tools.py:56
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:80
+#, fuzzy
 msgid "Last year"
+msgstr "Minulý rok"
+
+#. Translators: This message will never be used for less than
+#. 2 years ago. However, the singular form is necessary for some
+#. languages which do not have plural (Chinese, Japanese, Korean)
+#. or reuse the singular form for some plural cases (21 in Russian).
+#: ../src/gnome_abrt/tools.py:85
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} year ago"
 msgid_plural "{0:d} years ago"
 msgstr[0] "Minulý rok"
 msgstr[1] "Před {0:d} lety"

--- a/po/de.po
+++ b/po/de.po
@@ -291,31 +291,58 @@ msgstr "Keine Quelle"
 msgid "Not found in cache but deleted: {0}"
 msgstr "Nicht im Cache gefunden sondern gelöscht: {0}"
 
-#: ../src/gnome_abrt/tools.py:34
+#: ../src/gnome_abrt/tools.py:42
 msgid "Future"
 msgstr "Zukunft"
 
-#: ../src/gnome_abrt/tools.py:41
+#: ../src/gnome_abrt/tools.py:49
 msgid "Yesterday"
 msgstr "Gestern"
 
-#: ../src/gnome_abrt/tools.py:50
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:63
+#, fuzzy
 msgid "Last week"
+msgstr "Letzte Woche"
+
+#. Translators: This message will never be used for less than
+#. 2 weeks ago nor for more than one month ago. However, the singular
+#. form is necessary for some languages which do not have plural.
+#: ../src/gnome_abrt/tools.py:67
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} week ago"
 msgid_plural "{0:d} weeks ago"
 msgstr[0] "Letzte Woche"
 msgstr[1] "vor {0:d} Wochen"
 
-#: ../src/gnome_abrt/tools.py:53
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:72
+#, fuzzy
 msgid "Last month"
+msgstr "Letzter Monat"
+
+#. Translators: This message will never be used for less than
+#. 2 months ago nor for more than one year ago. See the comment above.
+#: ../src/gnome_abrt/tools.py:75
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} month ago"
 msgid_plural "{0:d} months ago"
 msgstr[0] "Letzter Monat"
 msgstr[1] "vor {0:d} Monaten"
 
-#: ../src/gnome_abrt/tools.py:56
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:80
+#, fuzzy
 msgid "Last year"
+msgstr "Letztes Jahr"
+
+#. Translators: This message will never be used for less than
+#. 2 years ago. However, the singular form is necessary for some
+#. languages which do not have plural (Chinese, Japanese, Korean)
+#. or reuse the singular form for some plural cases (21 in Russian).
+#: ../src/gnome_abrt/tools.py:85
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} year ago"
 msgid_plural "{0:d} years ago"
 msgstr[0] "Letztes Jahr"
 msgstr[1] "vor {0:d} Jahren"

--- a/po/es.po
+++ b/po/es.po
@@ -296,31 +296,58 @@ msgstr "Sin fuente"
 msgid "Not found in cache but deleted: {0}"
 msgstr "No  se encontró en cache pero fue borrada: {0}"
 
-#: ../src/gnome_abrt/tools.py:34
+#: ../src/gnome_abrt/tools.py:42
 msgid "Future"
 msgstr "Futuro"
 
-#: ../src/gnome_abrt/tools.py:41
+#: ../src/gnome_abrt/tools.py:49
 msgid "Yesterday"
 msgstr "Ayer"
 
-#: ../src/gnome_abrt/tools.py:50
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:63
+#, fuzzy
 msgid "Last week"
+msgstr "Semana pasada"
+
+#. Translators: This message will never be used for less than
+#. 2 weeks ago nor for more than one month ago. However, the singular
+#. form is necessary for some languages which do not have plural.
+#: ../src/gnome_abrt/tools.py:67
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} week ago"
 msgid_plural "{0:d} weeks ago"
 msgstr[0] "Semana pasada"
 msgstr[1] "Hace {0:d} semanas"
 
-#: ../src/gnome_abrt/tools.py:53
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:72
+#, fuzzy
 msgid "Last month"
+msgstr "Mes pasado"
+
+#. Translators: This message will never be used for less than
+#. 2 months ago nor for more than one year ago. See the comment above.
+#: ../src/gnome_abrt/tools.py:75
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} month ago"
 msgid_plural "{0:d} months ago"
 msgstr[0] "Mes pasado"
 msgstr[1] "Hace {0:d} meses"
 
-#: ../src/gnome_abrt/tools.py:56
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:80
+#, fuzzy
 msgid "Last year"
+msgstr "Año pasado"
+
+#. Translators: This message will never be used for less than
+#. 2 years ago. However, the singular form is necessary for some
+#. languages which do not have plural (Chinese, Japanese, Korean)
+#. or reuse the singular form for some plural cases (21 in Russian).
+#: ../src/gnome_abrt/tools.py:85
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} year ago"
 msgid_plural "{0:d} years ago"
 msgstr[0] "Año pasado"
 msgstr[1] "Hace {0:d} años"

--- a/po/fr.po
+++ b/po/fr.po
@@ -289,33 +289,60 @@ msgstr "Aucune source"
 msgid "Not found in cache but deleted: {0}"
 msgstr "Introuvable dans le cache mais supprimé : {0}"
 
-#: ../src/gnome_abrt/tools.py:34
+#: ../src/gnome_abrt/tools.py:42
 msgid "Future"
 msgstr "Futur"
 
-#: ../src/gnome_abrt/tools.py:41
+#: ../src/gnome_abrt/tools.py:49
 msgid "Yesterday"
 msgstr "Hier"
 
-#: ../src/gnome_abrt/tools.py:50
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:63
+#, fuzzy
 msgid "Last week"
+msgstr "La semaine dernière"
+
+#. Translators: This message will never be used for less than
+#. 2 weeks ago nor for more than one month ago. However, the singular
+#. form is necessary for some languages which do not have plural.
+#: ../src/gnome_abrt/tools.py:67
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} week ago"
 msgid_plural "{0:d} weeks ago"
-msgstr[0] "La semaine dernière"
+msgstr[0] "Il y a {0:d} semaine"
 msgstr[1] "Il y a {0:d} semaines"
 
-#: ../src/gnome_abrt/tools.py:53
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:72
+#, fuzzy
 msgid "Last month"
+msgstr "Le mois dernier"
+
+#. Translators: This message will never be used for less than
+#. 2 months ago nor for more than one year ago. See the comment above.
+#: ../src/gnome_abrt/tools.py:75
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} month ago"
 msgid_plural "{0:d} months ago"
-msgstr[0] "Le mois dernier"
+msgstr[0] "Il y a {0:d} mois"
 msgstr[1] "Il y a {0:d} mois"
 
-#: ../src/gnome_abrt/tools.py:56
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:80
+#, fuzzy
 msgid "Last year"
+msgstr "L'année dernière"
+
+#. Translators: This message will never be used for less than
+#. 2 years ago. However, the singular form is necessary for some
+#. languages which do not have plural (Chinese, Japanese, Korean)
+#. or reuse the singular form for some plural cases (21 in Russian).
+#: ../src/gnome_abrt/tools.py:85
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} year ago"
 msgid_plural "{0:d} years ago"
-msgstr[0] "L'année dernière"
+msgstr[0] "Il y a {0:d} an"
 msgstr[1] "Il y a {0:d} ans"
 
 #: ../src/gnome_abrt/views.py:283

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -290,31 +290,58 @@ msgstr "Nenhuma fonte"
 msgid "Not found in cache but deleted: {0}"
 msgstr "Não encontrado no cache mas excluído: {0}"
 
-#: ../src/gnome_abrt/tools.py:34
+#: ../src/gnome_abrt/tools.py:42
 msgid "Future"
 msgstr "Futuro"
 
-#: ../src/gnome_abrt/tools.py:41
+#: ../src/gnome_abrt/tools.py:49
 msgid "Yesterday"
 msgstr "Ontem"
 
-#: ../src/gnome_abrt/tools.py:50
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:63
+#, fuzzy
 msgid "Last week"
+msgstr "Semana passada"
+
+#. Translators: This message will never be used for less than
+#. 2 weeks ago nor for more than one month ago. However, the singular
+#. form is necessary for some languages which do not have plural.
+#: ../src/gnome_abrt/tools.py:67
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} week ago"
 msgid_plural "{0:d} weeks ago"
 msgstr[0] "Semana passada"
 msgstr[1] "{0:d} semanas atrás"
 
-#: ../src/gnome_abrt/tools.py:53
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:72
+#, fuzzy
 msgid "Last month"
+msgstr "Mês passado"
+
+#. Translators: This message will never be used for less than
+#. 2 months ago nor for more than one year ago. See the comment above.
+#: ../src/gnome_abrt/tools.py:75
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} month ago"
 msgid_plural "{0:d} months ago"
 msgstr[0] "Mês passado"
 msgstr[1] "{0:d} meses atrás"
 
-#: ../src/gnome_abrt/tools.py:56
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:80
+#, fuzzy
 msgid "Last year"
+msgstr "Ano passado"
+
+#. Translators: This message will never be used for less than
+#. 2 years ago. However, the singular form is necessary for some
+#. languages which do not have plural (Chinese, Japanese, Korean)
+#. or reuse the singular form for some plural cases (21 in Russian).
+#: ../src/gnome_abrt/tools.py:85
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} year ago"
 msgid_plural "{0:d} years ago"
 msgstr[0] "Ano passado"
 msgstr[1] "{0:d} anos atrás"

--- a/po/sk.po
+++ b/po/sk.po
@@ -272,33 +272,60 @@ msgstr "Žiadny zdroj"
 msgid "Not found in cache but deleted: {0}"
 msgstr ""
 
-#: ../src/gnome_abrt/tools.py:34
+#: ../src/gnome_abrt/tools.py:42
 msgid "Future"
 msgstr ""
 
-#: ../src/gnome_abrt/tools.py:41
+#: ../src/gnome_abrt/tools.py:49
 msgid "Yesterday"
 msgstr "Včera"
 
-#: ../src/gnome_abrt/tools.py:50
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:63
+#, fuzzy
 msgid "Last week"
+msgstr "Minulý týždeň"
+
+#. Translators: This message will never be used for less than
+#. 2 weeks ago nor for more than one month ago. However, the singular
+#. form is necessary for some languages which do not have plural.
+#: ../src/gnome_abrt/tools.py:67
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} week ago"
 msgid_plural "{0:d} weeks ago"
 msgstr[0] "Minulý týždeň"
 msgstr[1] "Pred {0:d} týždňami"
 msgstr[2] "Pred {0:d} týždňami"
 
-#: ../src/gnome_abrt/tools.py:53
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:72
+#, fuzzy
 msgid "Last month"
+msgstr "Minulý mesiac"
+
+#. Translators: This message will never be used for less than
+#. 2 months ago nor for more than one year ago. See the comment above.
+#: ../src/gnome_abrt/tools.py:75
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} month ago"
 msgid_plural "{0:d} months ago"
 msgstr[0] "Minulý mesiac"
 msgstr[1] "Pred {0:d} mesiacmi"
 msgstr[2] "Pred {0:d} mesiacmi"
 
-#: ../src/gnome_abrt/tools.py:56
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:80
+#, fuzzy
 msgid "Last year"
+msgstr "Minulý rok"
+
+#. Translators: This message will never be used for less than
+#. 2 years ago. However, the singular form is necessary for some
+#. languages which do not have plural (Chinese, Japanese, Korean)
+#. or reuse the singular form for some plural cases (21 in Russian).
+#: ../src/gnome_abrt/tools.py:85
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} year ago"
 msgid_plural "{0:d} years ago"
 msgstr[0] "Minulý rok"
 msgstr[1] "Pred {0:d} rokmi"

--- a/po/sr.po
+++ b/po/sr.po
@@ -281,33 +281,60 @@ msgstr "Нема извора"
 msgid "Not found in cache but deleted: {0}"
 msgstr "Није пронађено у кешу него у обрисаном: {0}"
 
-#: ../src/gnome_abrt/tools.py:34
+#: ../src/gnome_abrt/tools.py:42
 msgid "Future"
 msgstr "Будућност"
 
-#: ../src/gnome_abrt/tools.py:41
+#: ../src/gnome_abrt/tools.py:49
 msgid "Yesterday"
 msgstr "Јуче"
 
-#: ../src/gnome_abrt/tools.py:50
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:63
+#, fuzzy
 msgid "Last week"
+msgstr "Прошле недеље"
+
+#. Translators: This message will never be used for less than
+#. 2 weeks ago nor for more than one month ago. However, the singular
+#. form is necessary for some languages which do not have plural.
+#: ../src/gnome_abrt/tools.py:67
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} week ago"
 msgid_plural "{0:d} weeks ago"
 msgstr[0] "Прошле недеље"
 msgstr[1] "{0:d} недеља раније"
 msgstr[2] "{0:d} недеља раније"
 
-#: ../src/gnome_abrt/tools.py:53
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:72
+#, fuzzy
 msgid "Last month"
+msgstr "Прошли месец"
+
+#. Translators: This message will never be used for less than
+#. 2 months ago nor for more than one year ago. See the comment above.
+#: ../src/gnome_abrt/tools.py:75
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} month ago"
 msgid_plural "{0:d} months ago"
 msgstr[0] "Прошли месец"
 msgstr[1] "{0:d} месеци раније"
 msgstr[2] "{0:d} месеци раније"
 
-#: ../src/gnome_abrt/tools.py:56
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:80
+#, fuzzy
 msgid "Last year"
+msgstr "Прошле године"
+
+#. Translators: This message will never be used for less than
+#. 2 years ago. However, the singular form is necessary for some
+#. languages which do not have plural (Chinese, Japanese, Korean)
+#. or reuse the singular form for some plural cases (21 in Russian).
+#: ../src/gnome_abrt/tools.py:85
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} year ago"
 msgid_plural "{0:d} years ago"
 msgstr[0] "Прошле године"
 msgstr[1] "{0:d} година раније"

--- a/po/sv.po
+++ b/po/sv.po
@@ -286,31 +286,58 @@ msgstr "Ingen källa"
 msgid "Not found in cache but deleted: {0}"
 msgstr "Ej funnen i cachen men raderad: {0}"
 
-#: ../src/gnome_abrt/tools.py:34
+#: ../src/gnome_abrt/tools.py:42
 msgid "Future"
 msgstr "Framtid"
 
-#: ../src/gnome_abrt/tools.py:41
+#: ../src/gnome_abrt/tools.py:49
 msgid "Yesterday"
 msgstr "Igår"
 
-#: ../src/gnome_abrt/tools.py:50
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:63
+#, fuzzy
 msgid "Last week"
+msgstr "Senaste veckan"
+
+#. Translators: This message will never be used for less than
+#. 2 weeks ago nor for more than one month ago. However, the singular
+#. form is necessary for some languages which do not have plural.
+#: ../src/gnome_abrt/tools.py:67
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} week ago"
 msgid_plural "{0:d} weeks ago"
 msgstr[0] "Senaste veckan"
 msgstr[1] "Sedan {0:d} veckor"
 
-#: ../src/gnome_abrt/tools.py:53
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:72
+#, fuzzy
 msgid "Last month"
+msgstr "Senaste månaden"
+
+#. Translators: This message will never be used for less than
+#. 2 months ago nor for more than one year ago. See the comment above.
+#: ../src/gnome_abrt/tools.py:75
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} month ago"
 msgid_plural "{0:d} months ago"
 msgstr[0] "Senaste månaden"
 msgstr[1] "Sedan {0:d} månader"
 
-#: ../src/gnome_abrt/tools.py:56
-#, python-brace-format
+#: ../src/gnome_abrt/tools.py:80
+#, fuzzy
 msgid "Last year"
+msgstr "Senaste året"
+
+#. Translators: This message will never be used for less than
+#. 2 years ago. However, the singular form is necessary for some
+#. languages which do not have plural (Chinese, Japanese, Korean)
+#. or reuse the singular form for some plural cases (21 in Russian).
+#: ../src/gnome_abrt/tools.py:85
+#, python-brace-format
+#, fuzzy
+msgid "{0:d} year ago"
 msgid_plural "{0:d} years ago"
 msgstr[0] "Senaste året"
 msgstr[1] "Sedan {0:d} år"


### PR DESCRIPTION
Some translations became broken due to the recent change
introduced in pull request #143 (commit 43236a4). This commit is not
a complete fix, just restores the state which had been before.