### PR TITLE
Let main title of the crash wrap

### DIFF
--- a/src/gnome_abrt/oops.glade
+++ b/src/gnome_abrt/oops.glade
@@ -418,8 +418,10 @@
                                             <property name="margin_top">19</property>
                                             <property name="label">Application killed by signal</property>
                                             <property name="wrap">True</property>
+                                            <property name="wrap-mode">word-char</property>
+                                            <property name="width-chars">20</property>
                                             <property name="selectable">True</property>
-                                            <property name="ellipsize">end</property>
+                                            <property name="ellipsize">none</property>
                                             <style>
                                               <class name="oops-reason"/>
                                             </style>


### PR DESCRIPTION
The application name plus the words "quit unexpectedly" can be
long in some translations. Wrapping will not work if a label can
ellipsize so ellipsizing turned off. At the same time:
- wrapping mode set to word-char for some apps with
  crazy-very-long-names-without-spaces,
- minimum width set to 20 chars to make sure it does not break
  normal words which can legally be long.

(Spotted with the crashed application GNOME Software and LANG=pl_PL.utf8)