### PR TITLE
Correct format of the package version

### DIFF
--- a/src/gnome_abrt/problems.py
+++ b/src/gnome_abrt/problems.py
@@ -261,7 +261,7 @@ class Problem(object):
         arch = self['pkg_arch']
 
         if version and release and arch:
-            return "{0}{1}.{2}.{3}".format(epoch, version, release, arch)
+            return "{0}{1}-{2}.{3}".format(epoch, version, release, arch)
 
         return self['package']
 


### PR DESCRIPTION
The correct version is "version-release", not "version.release".

Resolves: rhbz#1326430

Looks trivial. I think it would be good to backport this to all alive old branches.