### PR TITLE
Use compatible CSS selectors for both gtk 3.18 and 3.20

### DIFF
--- a/src/gnome_abrt/views.py
+++ b/src/gnome_abrt/views.py
@@ -474,7 +474,11 @@ class OopsWindow(Gtk.ApplicationWindow):
 
         #pylint: disable=E1120
         css_prv = Gtk.CssProvider.new()
-        css_prv.load_from_data("GtkListBoxRow {\n"
+        # "row" selector is valid and supported in GTK>=3.20 (Fedora 24).
+        # "GtkListBoxRow" selector is no longer supported but required
+        # for GTK<3.20 (Fedora 23). It can be removed if we decide to stop
+        # supporting older systems.
+        css_prv.load_from_data("GtkListBoxRow, row {\n"
                                "  padding          : 12px;\n"
                                "}\n"
                                ".app-name-label {\n"


### PR DESCRIPTION
We need "GtkListBoxRow" for pre-3.20 and "row" for 3.20 and later.
Otherwise the selector does not work and problem list items lose
their nice padding.

Closes #174