### PR TITLE
No expert mode + make "--help" fully translated

### DIFF
--- a/src/gnome-abrt
+++ b/src/gnome-abrt
@@ -397,8 +397,23 @@ if __name__ == "__main__":
 
     CMDARGS = ArgumentParser(
             description=_('View and report application crashes'))
+    # pylint: disable=W0105
+    '''
+    Again a trick to make xgettext think we are C language and emit the
+    translators comment correctly.
+    See: bugs.launchpad.net/intltool/+bug/377872
+    // Translators: This is a description of --verbose command line option
+    // displayed when a user runs: `gnome-abrt --help'
+    _("Be verbose")
+    '''
     CMDARGS.add_argument('-v', '--verbose', action='count',
             help=_('Be verbose'))
+    # pylint: disable=W0105
+    '''
+    // Translators: This is a description of --problem command line option
+    // displayed when a user runs: `gnome-abrt --help'
+    _("Selected problem ID")
+    '''
     CMDARGS.add_argument('-p', '--problem',
             help=_('Selected problem ID'))
 

--- a/src/gnome-abrt
+++ b/src/gnome-abrt
@@ -401,8 +401,6 @@ if __name__ == "__main__":
             help=_('Be verbose'))
     CMDARGS.add_argument('-p', '--problem',
             help=_('Selected problem ID'))
-    CMDARGS.add_argument('-x', '--expert', action='store_true',
-            help=_('Expert mode'))
 
     OPTIONS = CMDARGS.parse_args()
 
@@ -414,7 +412,6 @@ if __name__ == "__main__":
     CONF = get_configuration()
     # TODO : mark this option as hidden or something like that
     CONF.add_option('problemid', default_value=None)
-    CONF.add_option('expert', default_value=(OPTIONS.expert))
 
     APP_CMDLINE = []
     if 'problem' in VARS:

--- a/src/gnome_abrt/controller.py.in
+++ b/src/gnome_abrt/controller.py.in
@@ -45,13 +45,6 @@ class Controller(object):
 
         problem.delete()
 
-    def analyze(self, problem):
-        if not problem:
-            logging.error("BUG: Controller: Can't open detail of None problem")
-            return
-
-        self.run_event_fn("open-gui", problem)
-
     def _refresh_sources(self):
         for name, src in self.sources:
             try:

--- a/src/gnome_abrt/oops.glade
+++ b/src/gnome_abrt/oops.glade
@@ -23,14 +23,6 @@
       <accelerator key="Return"/>
     </child>
     <child>
-      <object class="GtkAction" id="gac_analyze">
-        <property name="label" translatable="yes">Analy_ze</property>
-        <property name="tooltip" translatable="yes">Open selected problem for analysis</property>
-        <signal name="activate" handler="on_gac_analyze_activate" swapped="no"/>
-      </object>
-      <accelerator key="Return" modifiers="GDK_CONTROL_MASK | GDK_MOD1_MASK"/>
-    </child>
-    <child>
       <object class="GtkAction" id="gac_detail">
         <property name="label" translatable="yes">D_etails</property>
         <property name="tooltip" translatable="yes">Show technical details</property>

--- a/src/gnome_abrt/views.py
+++ b/src/gnome_abrt/views.py
@@ -527,7 +527,6 @@ class OopsWindow(Gtk.ApplicationWindow):
         conf.set_watch('T_FMT', self._options_observer)
         conf.set_watch('D_T_FMT', self._options_observer)
         self._options_observer.option_updated(conf, 'problemid')
-        self._builder.mi_detail.set_visible(conf['expert'])
 
         # enable observer
         self._source_observer.enable()
@@ -1000,12 +999,6 @@ _("This problem has been reported, but a <i>Bugzilla</i> ticket has not"
         if selected:
             wrappers.show_problem_details_for_dir(
                     selected[0].problem_id, self)
-
-    @handle_problem_and_source_errors
-    def on_gac_analyze_activate(self, action):
-        selected = self._get_selected(self.lss_problems)
-        if selected:
-            self._controller.analyze(selected[0])
 
     @handle_problem_and_source_errors
     def on_gac_report_activate(self, action):


### PR DESCRIPTION
This pull request contains 2 commits:

1. Remove the expert mode which has not been useful for a while already.
1. Make ```gnome-abrt --help``` fully translated (well, almost fully but the remaining untranslated part is not our fault).