### PR TITLE
Fix incorrect parsing of reported_to file

### DIFF
--- a/src/gnome_abrt/problems.py
+++ b/src/gnome_abrt/problems.py
@@ -280,7 +280,7 @@ class Problem(object):
 
     def get_submission(self):
         if not self.submission:
-            reg = re.compile(r'^(?P<pfx>.*):\s*(?P<typ>\S*)=(?P<data>.*)')
+            reg = re.compile(r'^(?P<pfx>.*?):\s*(?P<typ>\S*?)=(?P<data>.*)')
             self.submission = []
             if self['reported_to']:
                 # Most common type of line in reported_to file


### PR DESCRIPTION
Fixes BZ#1600809

Bug was introduced in commit 99578c5.
Adding lazy operator (?) makes sure, that first occurrences are found.
This did not work on following item:
    Bugzilla: URL=https://bugzilla.redhat.com/show_bug.cgi?id=123456
Without this fix, it was split as:
    - Bugzilla: URL=https
    - //bugzilla.redhat.com/show_bug.cgi
    - id=123456

With this fix first ':' and '=' are found correctly.

Signed-off-by: Matej Marusak <mmarusak@redhat.com>