### PR TITLE
spec: Fix files listed twice

### DIFF
--- a/gnome-abrt.spec.in
+++ b/gnome-abrt.spec.in
@@ -81,7 +81,6 @@ make check || :
 %doc COPYING README.md
 %{python3_sitearch}/gnome_abrt
 %{_datadir}/%{name}
-%{_datadir}/%{name}/ui
 %{_bindir}/%{name}
 %{_datadir}/applications/*
 %{_datadir}/metainfo/*


### PR DESCRIPTION
`%{_datadir}/%{name}` - already includes the directory and entire tree below it.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>