### PR TITLE
spec: Fix python3 libreport dependency

### DIFF
--- a/gnome-abrt.spec.in
+++ b/gnome-abrt.spec.in
@@ -22,7 +22,7 @@ BuildRequires: asciidoc
 BuildRequires: xmlto
 BuildRequires: pygobject3-devel
 BuildRequires: libreport-gtk-devel > 2.4.0
-BuildRequires: libreport-python3
+BuildRequires: python3-libreport
 BuildRequires: abrt-gui-devel > 2.4.0
 BuildRequires: gtk3-devel
 BuildRequires: libX11-devel
@@ -37,7 +37,7 @@ BuildRequires: python3-humanize
 %define checkoption --with-nopylint
 %endif
 
-Requires:   libreport-python3
+Requires:   python3-libreport
 Requires:   python3-inotify
 Requires:   python3-gobject
 Requires:   python3-dbus


### PR DESCRIPTION
libreport-python3 was rename to python3-libreport

https://github.com/abrt/libreport/commit/45117d9f6e5eb533b226286aeb47984fb17e173e

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>