### PR TITLE
Replace deprecated GtkApplication.add_accelerator()

### DIFF
--- a/src/gnome-abrt
+++ b/src/gnome-abrt
@@ -328,7 +328,7 @@ class OopsApplication(Gtk.Application):
         action = Gio.SimpleAction.new("quit", None)
         action.connect("activate", self.on_action_quit)
         self.add_action(action)
-        self.add_accelerator("<Control>q", "app.quit")
+        self.set_accels_for_action("app.quit", ["<Control>q"])
 
         self.set_app_menu(menu)
 


### PR DESCRIPTION
Using set_accels_for_action() instead is suggested.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>