### PR TITLE
problems: Only read URLs before the first whitespace

### DIFF
--- a/src/gnome_abrt/problems.py
+++ b/src/gnome_abrt/problems.py
@@ -280,7 +280,7 @@ class Problem:
 
     def get_submission(self):
         if not self.submission:
-            reg = re.compile(r'^(?P<pfx>.*?):\s*(?P<typ>\S*?)=(?P<data>.*)')
+            reg = re.compile(r'^(?P<pfx>.*?):\s*(?P<typ>\S*?)=(?P<data>[^\s]+)')
             self.submission = []
             if self['reported_to']:
                 # Most common type of line in reported_to file


### PR DESCRIPTION
Adding new fields to reported_to, reading URLs might fail, as it will
include everything past “URL=”.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>