### PR TITLE
Remove unused "import _"

### DIFF
--- a/src/gnome_abrt/controller.py.in
+++ b/src/gnome_abrt/controller.py.in
@@ -22,7 +22,6 @@ import traceback
 
 # gnome-abrt
 from gnome_abrt import errors
-from gnome_abrt.l10n import _
 
 class Controller:
 

--- a/src/gnome_abrt/directory_problems.py
+++ b/src/gnome_abrt/directory_problems.py
@@ -32,7 +32,6 @@ from pyinotify import WatchManager, Notifier, ProcessEvent
 # gnome-abrt
 from gnome_abrt import problems
 from gnome_abrt import errors
-from gnome_abrt.l10n import _
 
 class INOTIFYGlibSource(GLib.Source):
 

--- a/src/gnome_abrt/problems.py
+++ b/src/gnome_abrt/problems.py
@@ -24,7 +24,6 @@ import gnome_abrt.url
 from gnome_abrt.application import find_application
 from gnome_abrt.errors import (InvalidProblem,
                                UnavailableSource)
-from gnome_abrt.l10n import _
 
 class ProblemSource:
     NEW_PROBLEM = 0


### PR DESCRIPTION
Commit 77f85890b62130f46fc66291011ac3bdb2c13d99 unmarked some messages
from translation. Now "_" is no longer used in some files and the Python
linter complains with the following message:

    [W0611(unused-import), ] Unused _ imported from gnome_abrt.l10n

which makes the package FTBFS in Fedora. This commit removes unused
imports.