### PR TITLE
l10n: Set text domain for Python locale module

### DIFF
--- a/src/gnome_abrt/l10n.py
+++ b/src/gnome_abrt/l10n.py
@@ -47,6 +47,9 @@ def init(progname, localedir='/usr/share/locale'):
     gettext.bindtextdomain(progname, localedir)
     gettext.textdomain(progname)
 
+    locale.bindtextdomain(progname, localedir)
+    locale.textdomain(progname)
+
 def pgettext(context, message):
     result = gettext.gettext(context + "\004" + message)
     if "\004" in result:


### PR DESCRIPTION
Setting the text domain for the gettext module does not affect any C
libraries that call gettext functions, resulting in some of the
translations not appearing.

Fixes https://github.com/abrt/gnome-abrt/issues/220

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>