### PR TITLE
oops-window.ui: Redo layout

### DIFF
--- a/data/ui/oops-window.ui
+++ b/data/ui/oops-window.ui
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <template class="OopsWindow" parent="GtkApplicationWindow">
-    <property name="width_request">1024</property>
-    <property name="height_request">768</property>
-    <property name="can_focus">False</property>
+    <property name="default-width">1024</property>
+    <property name="default-height">768</property>
     <property name="icon_name">gnome-abrt</property>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="header_bar">
@@ -92,7 +91,6 @@
     <child>
       <object class="GtkBox" id="box_window">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkPaned" id="gr_main_layout">
@@ -105,15 +103,13 @@
             <child>
               <object class="GtkBox" id="box_panel_left">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkSearchBar" id="search_bar">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
                     <property name="show-close-button">False</property>
                     <child>
-                    <object class="GtkSearchEntry" id="se_problems">
+                      <object class="GtkSearchEntry" id="se_problems">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="can_default">True</property>
@@ -140,23 +136,12 @@
                 <child>
                   <object class="GtkBox" id="vbox_problems">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkBox" id="hbox_source_btns">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -173,11 +158,9 @@
                         <child>
                           <object class="GtkViewport" id="viewport1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkListBox" id="lb_problems">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
                                 <property name="selection_mode">browse</property>
                                 <signal name="button-press-event" handler="problems_button_press_event" swapped="no"/>
                               </object>
@@ -205,455 +188,251 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="box_panel_right">
+              <object class="GtkStack" id="nb_problem_layout">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
+                <property name="expand">True</property>
+                <property name="margin">18</property>
                 <child>
-                  <object class="GtkNotebook" id="nb_problem_layout">
+                  <object class="GtkBox" id="gd_problem_info">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="hexpand">True</property>
-                    <property name="vexpand">True</property>
-                    <property name="show_tabs">False</property>
-                    <property name="show_border">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">18</property>
                     <child>
-                      <object class="GtkBox" id="box3">
+                      <object class="GtkBox">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
+                        <property name="spacing">12</property>
                         <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow2">
+                          <object class="GtkImage" id="img_app_icon">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="hscrollbar_policy">never</property>
-                            <property name="vscrollbar_policy">automatic</property>
+                            <property name="icon_name">image-missing-symbolic</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="hexpand">True</property>
+                            <property name="orientation">vertical</property>
+                            <property name="margin-top">12</property>
                             <child>
-                              <object class="GtkViewport" id="viewport2">
+                              <object class="GtkLabel" id="lbl_reason">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkGrid" id="gd_problem_info">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_start">24</property>
-                                    <property name="margin_end">24</property>
-                                    <property name="margin_top">32</property>
-                                    <property name="hexpand">True</property>
-                                    <child>
-                                      <object class="GtkImage" id="img_app_icon">
-                                        <property name="width_request">156</property>
-                                        <property name="height_request">132</property>
-                                        <property name="margin_top">12</property>
-                                        <property name="margin_bottom">12</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="halign">center</property>
-                                        <property name="valign">start</property>
-                                        <property name="icon_name">image-missing-symbolic</property>
-                                        <property name="icon_size">3</property>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">0</property>
-                                        <property name="top_attach">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="vbx_problem_header">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="hexpand">True</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="margin_bottom">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="lbl_reason">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="hexpand">True</property>
-                                            <property name="xalign">0</property>
-                                            <property name="yalign">0</property>
-                                            <property name="margin_top">19</property>
-                                            <property name="label">Application killed by signal</property>
-                                            <property name="wrap">True</property>
-                                            <property name="wrap-mode">word-char</property>
-                                            <property name="width-chars">20</property>
-                                            <property name="selectable">True</property>
-                                            <property name="ellipsize">none</property>
-                                            <style>
-                                              <class name="oops-reason"/>
-                                            </style>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="lbl_summary">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="hexpand">True</property>
-                                            <property name="xalign">0</property>
-                                            <property name="yalign">0</property>
-                                            <property name="label">Application can't continue becuase of received signal</property>
-                                            <property name="wrap">True</property>
-                                            <property name="selectable">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="top_attach">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_app_name">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="halign">end</property>
-                                        <property name="margin_end">12</property>
-                                        <property name="margin_top">8</property>
-                                        <property name="margin_bottom">8</property>
-                                        <property name="label" translatable="yes">Name</property>
-                                        <property name="wrap">True</property>
-                                        <style>
-                                          <class name="dim-label"/>
-                                        </style>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">0</property>
-                                        <property name="top_attach">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_app_version">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="halign">end</property>
-                                        <property name="margin_end">12</property>
-                                        <property name="margin_top">8</property>
-                                        <property name="margin_bottom">8</property>
-                                        <property name="label" translatable="yes">Version</property>
-                                        <style>
-                                          <class name="dim-label"/>
-                                        </style>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">0</property>
-                                        <property name="top_attach">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_detected">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="halign">end</property>
-                                        <property name="margin_end">12</property>
-                                        <property name="margin_top">8</property>
-                                        <property name="margin_bottom">8</property>
-                                        <property name="label" translatable="yes" comments="Translators: A label for a date when the bug happened for the first time. Please keep this label short, below 156px if possible.">First Detected</property>
-                                        <style>
-                                          <class name="dim-label"/>
-                                        </style>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">0</property>
-                                        <property name="top_attach">3</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_app_name_value">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="halign">start</property>
-                                        <property name="label">app</property>
-                                        <property name="selectable">True</property>
-                                        <property name="ellipsize">end</property>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="top_attach">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_app_version_value">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="halign">start</property>
-                                        <property name="label">2.0.13-2</property>
-                                        <property name="selectable">True</property>
-                                        <property name="ellipsize">end</property>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="top_attach">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_detected_value">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="halign">start</property>
-                                        <property name="label">2013-04-09 18:55</property>
-                                        <property name="selectable">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="top_attach">3</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="vbx_links">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_top">3</property>
-                                        <property name="hexpand">True</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkLabel" id="lbl_reported_value">
-                                            <property name="can_focus">False</property>
-                                            <property name="no_show_all">True</property>
-                                            <property name="halign">start</property>
-                                            <property name="margin_top">5</property>
-                                            <property name="label">no</property>
-                                            <property name="selectable">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="label1">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="margin_top">8</property>
-                                            <property name="margin_bottom">8</property>
-                                            <property name="label">&lt;a href="https://glade.gnome.org/"&gt;Very long placeholder URL tile&lt;/a&gt;</property>
-                                            <property name="use_markup">True</property>
-                                            <property name="ellipsize">middle</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="label2">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="margin_top">8</property>
-                                            <property name="margin_bottom">8</property>
-                                            <property name="label">&lt;a href="https://github.com/abrt/gnome-abrt"&gt;Placeholder URL&lt;/a&gt;</property>
-                                            <property name="use_markup">True</property>
-                                            <property name="lines">1</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="top_attach">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_reported">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">start</property>
-                                        <property name="margin_end">12</property>
-                                        <property name="margin_top">8</property>
-                                        <property name="margin_bottom">8</property>
-                                        <property name="label" translatable="yes">Reported</property>
-                                        <property name="wrap">True</property>
-                                        <style>
-                                          <class name="dim-label"/>
-                                        </style>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">0</property>
-                                        <property name="top_attach">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="vbx_problem_messages">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_top">12</property>
-                                        <property name="vexpand">True</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">0</property>
-                                        <property name="top_attach">5</property>
-                                        <property name="width">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                  </object>
-                                </child>
+                                <property name="xalign">0</property>
+                                <property name="label">Application killed by signal</property>
+                                <property name="wrap">True</property>
+                                <property name="wrap-mode">word-char</property>
+                                <property name="width-chars">20</property>
+                                <property name="selectable">True</property>
+                                <style>
+                                  <class name="oops-reason"/>
+                                </style>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="lbl_summary">
+                                <property name="visible">True</property>
+                                <property name="xalign">0</property>
+                                <property name="yalign">0</property>
+                                <property name="label">Application can't continue becuase of received signal</property>
+                                <property name="wrap">True</property>
+                                <property name="selectable">True</property>
                               </object>
                             </child>
                           </object>
                         </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkGrid">
+                        <property name="visible">True</property>
+                        <property name="column-spacing">12</property>
+                        <property name="row-spacing">12</property>
+                        <property name="margin-start">36</property>
                         <child>
-                          <object class="GtkButton" id="btn_detail">
-                            <property name="label" translatable="yes">D_etails</property>
-                            <property name="tooltip_text" translatable="yes">Show problem details</property>
-                            <property name="use-underline">True</property>
-                            <property name="action-name">win.details</property>
+                          <object class="GtkLabel" id="lbl_app_name">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
                             <property name="halign">end</property>
-                            <property name="margin_start">12</property>
-                            <property name="margin_end">12</property>
-                            <property name="margin_top">12</property>
-                            <property name="margin_bottom">12</property>
+                            <property name="label" translatable="yes">Name</property>
+                            <property name="wrap">True</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
                           </object>
                         </child>
-                      </object>
-                    </child>
-                    <child type="tab">
-                      <object class="GtkLabel" id="lbl_page_problem">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label">Problem page</property>
-                      </object>
-                      <packing>
-                        <property name="tab_fill">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="vbx_empty_page">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkLabel" id="lbl_no_oopses">
+                          <object class="GtkLabel" id="lbl_app_name_value">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="hexpand">True</property>
-                            <property name="vexpand">True</property>
-                            <property name="label" translatable="yes">No problems detected!</property>
+                            <property name="halign">start</property>
+                            <property name="label">app</property>
                             <property name="selectable">True</property>
+                            <property name="ellipsize">end</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="lbl_app_version">
+                            <property name="visible">True</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">Version</property>
                             <style>
                               <class name="dim-label"/>
                             </style>
                           </object>
                           <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">0</property>
                           </packing>
                         </child>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child type="tab">
-                      <object class="GtkLabel" id="lbl_page_empty">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label">Empty page</property>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                        <property name="tab_fill">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="vbx_no_source_page">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkLabel" id="lbl_no_source">
+                          <object class="GtkLabel" id="lbl_app_version_value">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="hexpand">True</property>
-                            <property name="vexpand">True</property>
-                            <property name="label" translatable="yes">No source selected!</property>
+                            <property name="halign">start</property>
+                            <property name="label">2.0.13-2</property>
                             <property name="selectable">True</property>
+                            <property name="ellipsize">end</property>
+                          </object>
+                          <packing>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="lbl_detected">
+                            <property name="visible">True</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes" comments="Translators: A label for a date when the bug happened for the first time. Please keep this label short, below 156px if possible.">First Detected</property>
                             <style>
                               <class name="dim-label"/>
                             </style>
                           </object>
                           <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="lbl_detected_value">
+                            <property name="visible">True</property>
+                            <property name="halign">start</property>
+                            <property name="label">2013-04-09 18:55</property>
+                            <property name="selectable">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="lbl_reported">
+                            <property name="visible">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">start</property>
+                            <property name="label" translatable="yes">Reported</property>
+                            <property name="wrap">True</property>
+                            <style>
+                              <class name="dim-label"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="vbx_links">
+                            <property name="visible">True</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkLabel" id="lbl_reported_value">
+                                <property name="no_show_all">True</property>
+                                <property name="halign">start</property>
+                                <property name="label">no</property>
+                                <property name="selectable">True</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">3</property>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="position">2</property>
-                      </packing>
                     </child>
-                    <child type="tab">
-                      <object class="GtkLabel" id="lbl_page_no_source">
+                    <child>
+                      <object class="GtkBox" id="vbx_problem_messages">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">No source</property>
+                        <property name="vexpand">True</property>
+                        <property name="orientation">vertical</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="btn_detail">
+                        <property name="label" translatable="yes">D_etails</property>
+                        <property name="tooltip_text" translatable="yes">Show problem details</property>
+                        <property name="use-underline">True</property>
+                        <property name="action-name">win.details</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="halign">end</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox" id="vbx_empty_page">
+                    <property name="visible">True</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkLabel" id="lbl_no_oopses">
+                        <property name="visible">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="label" translatable="yes">No problems detected!</property>
+                        <property name="selectable">True</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
                       </object>
                       <packing>
-                        <property name="position">2</property>
-                        <property name="tab_fill">False</property>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkBox" id="vbx_no_source_page">
+                    <property name="visible">True</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkLabel" id="lbl_no_source">
+                        <property name="visible">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="label" translatable="yes">No source selected!</property>
+                        <property name="selectable">True</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
               </object>
-              <packing>
-                <property name="resize">True</property>
-                <property name="shrink">False</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <placeholder/>
         </child>
       </object>
     </child>

--- a/src/gnome_abrt/views.py
+++ b/src/gnome_abrt/views.py
@@ -313,6 +313,9 @@ class OopsWindow(Gtk.ApplicationWindow):
     vbx_problem_messages = Gtk.Template.Child()
     tbtn_search = Gtk.Template.Child()
     tbtn_multi_select = Gtk.Template.Child()
+    gd_problem_info = Gtk.Template.Child()
+    vbx_empty_page = Gtk.Template.Child()
+    vbx_no_source_page = Gtk.Template.Child()
 
     def placeholder_mapped(self, label, data):
         self.tbtn_multi_select.set_sensitive(False)
@@ -762,8 +765,6 @@ class OopsWindow(Gtk.ApplicationWindow):
                 lnk.set_markup(
                     "<a href=\"{0}\">{1}</a>".format(sbm.data, sbm.title))
                 lnk.set_halign(Gtk.Align.START)
-                lnk.set_margin_top(5)
-                lnk.set_margin_bottom(8)
                 lnk.set_line_wrap(True)
                 lnk.set_visible(True)
 
@@ -799,7 +800,7 @@ class OopsWindow(Gtk.ApplicationWindow):
         self.vbx_problem_messages.foreach(lambda w, u: w.destroy(), None)
 
         if problem:
-            self.nb_problem_layout.set_current_page(0)
+            self.nb_problem_layout.set_visible_child(self.gd_problem_info)
             app = problem['application']
             if problem['type'] == 'Kerneloops':
                 self.lbl_reason.set_text(
@@ -892,9 +893,9 @@ _("This problem has been reported, but a <i>Bugzilla</i> ticket has not"
                 self.lbl_reported_value.set_text(_('no'))
         else:
             if self._source is not None:
-                self.nb_problem_layout.set_current_page(1)
+                self.nb_problem_layout.set_visible_child(self.vbx_empty_page)
             else:
-                self.nb_problem_layout.set_current_page(2)
+                self.nb_problem_layout.set_visible_child(self.vbx_no_source_page)
 
     def _get_selected(self, selection):
         return selection.get_selected_rows()


### PR DESCRIPTION
Quite a bit going on in this one:

  * Size request of window replaced with default size, as there is no
reason to restrict sizing down
  * Removed scrolled window in the content pane - it’s not quite useful
right now, since there aren’t too many place where reports can be sent,
and the problem message box will only ever really contain a single
label. If there is a future where this causes problems, it would be
better to experiment with a different design than just make it
scrollable.
  * Content pane notebook replaced with a stack - seriously, a notebook
is not the tool for the job.
  * Margins on individual widgets replaced with container spacing.
  * Removed redundant properties - GtkWidget:can-focus is false by
default (Glade, I’m looking at you).
  * Removed pointless placeholder children.
  * Added more subcontainers to the main content grid, so things are
easier to manage.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1683743

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>