### PR TITLE
views: Set LIBREPORT_PRGNAME when reporting

### DIFF
--- a/src/gnome_abrt/views.py
+++ b/src/gnome_abrt/views.py
@@ -955,6 +955,8 @@ _("This problem has been reported, but a <i>Bugzilla</i> ticket has not"
     def on_gac_report_activate(self, action, parameter):
         selected = self._get_selected(self.lss_problems)
         if selected and not selected[0]['not-reportable']:
+            # For gnome-shell to associate the child process windows with this application.
+            os.environ["LIBREPORT_PRGNAME"] = self.get_application().get_application_id()
             self._controller.report(selected[0])
 
     @Gtk.Template.Callback()


### PR DESCRIPTION
After 0ef2d55e6c68fc012b88b2d0b8b4501dbef5c993, gnome-shell can no
longer fall back to gnome-abrt.desktop for report-gtk. Luckily,
libreport uses an environment variable to set the program name before
running, which is what is used as WM_CLASS (in gnome-shell terms).

Resolves https://github.com/abrt/gnome-abrt/issues/230

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>