### PR TITLE
Add translators comment in menu

### DIFF
--- a/data/ui/oops-menus.ui
+++ b/data/ui/oops-menus.ui
@@ -44,7 +44,9 @@
       <attribute name="action">app.preferences</attribute>
     </item>
     <item>
-      <attribute name="label" translatable="yes">_About Problem Reporting</attribute>
+      <attribute
+          comments="Translators: This is the menu item which displays the About box. Note that &quot;Problem Reporting&quot; is the name of this application."
+          name="label" translatable="yes">_About Problem Reporting</attribute>
       <attribute name="action">app.about</attribute>
     </item>
   </menu>


### PR DESCRIPTION
It may be confusing for translators whether ```About Problem Reporting``` is about this application (correct) or about problem reporting in general (incorrect).

I asked some translators. Some of them understood the meaning correctly, some said that their translation is correct (even although it looked suspicious for me), one fixed his translation, one suggested that a comment would be a good thing.