### PR TITLE
Minor ELN conditional fixes

### DIFF
--- a/gnome-abrt.spec
+++ b/gnome-abrt.spec
@@ -35,7 +35,7 @@ BuildRequires: libreport-gtk-devel > 2.4.0
 BuildRequires: python3-libreport
 BuildRequires: abrt-gui-devel > 2.4.0
 BuildRequires: gtk3-devel
-%if 0%{?fedora}
+%if 0%{?fedora} || 0%{?rhel} >= 9
 BuildRequires: python3-pylint
 BuildRequires: python3-six
 BuildRequires: python3-gobject
@@ -62,7 +62,9 @@ provides them with convenient way for managing these problems.
 
 %build
 %meson \
-    %{!?fedora:-Dlint=false} \
+%if 0%{?rhel} && 0%{?rhel} < 9
+    -Dlint=false \
+%endif
     %{nil}
 %meson_build
 


### PR DESCRIPTION
This PR replicates the changes made to `gnome-abrt.spec` by downstream PR https://src.fedoraproject.org/rpms/gnome-abrt/pull-request/19 for fix builds for ELN.

Please note, however, that `gnome-abrt.spec` is still out of sync with downtream:

- Downstream has an added patch: https://src.fedoraproject.org/rpms/gnome-abrt/c/8e0b75fea8558f0844731987aa34607f0469f244?branch=master by @ernestask 
- Upstream dropped `[Build]Requires` for `python3-inotify`: https://github.com/abrt/gnome-abrt/commit/2a95e02b412ec8a9c68c5a2144f2731f66e2b44c by @ernestask