### PR TITLE
Handle ConnectionError when fetching report title

### DIFF
--- a/src/gnome_abrt/problems.py
+++ b/src/gnome_abrt/problems.py
@@ -130,7 +130,9 @@ class Problem:
                         value = GObject.Value(str, soup.title.string)
 
                         task.return_value(value)
-                    except (urllib.error.HTTPError, urllib.error.URLError) as ex:
+                    except (urllib.error.HTTPError,
+                            urllib.error.URLError,
+                            ConnectionError) as ex:
                         error = GLib.Error("Fetching title for problem report failed: %s" % (ex))
                         task.return_error(error)
 


### PR DESCRIPTION
Handle the lower-level ConnectionError in addition to urllib's HTTP errors since they don't seem to include situations such as the "connection reset" error.

Fixes #297
Fixes [rhbz#1928452](https://bugzilla.redhat.com/show_bug.cgi?id=1928452)