### PR TITLE
Fix lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,11 +23,11 @@ jobs:
         run: dnf builddep --assumeyes --spec gnome-abrt.spec
 
       - name: Configure build
-        run: meson build
+        run: meson setup build
 
       - name: Build and install packages
         run: |
-            meson compile -C build rpm
+            meson compile -C build rpm -v
             dnf --assumeyes install ./build/rpm/**/*.rpm
 
       - name: Run pylint

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,12 @@ xmlto = find_program('xmlto',
   required: get_option('docs')
 )
 
+configure_file(
+  copy: true,
+  input: 'gnome-abrt.spec',
+  output: 'gnome-abrt.spec',
+)
+
 subdir('data')
 subdir('doc')
 subdir('icons')

--- a/src/gnome_abrt/views.py
+++ b/src/gnome_abrt/views.py
@@ -93,8 +93,9 @@ class ProblemsFilter:
 
                 # _pattern is 'str' and sbm.data is 'dbus.String', so we need
                 # to convert sbm.data to a regular 'str'
-                rid = str(sbm.data).rstrip('/')
-                rid = rid.rsplit('/', maxsplit=1)[-1].rsplit('=', maxsplit=1)[-1]
+                rid = str(sbm.data)
+                rid = rid.rstrip('/').rsplit('/', maxsplit=1)[-1]
+                rid = rid.rsplit('=', maxsplit=1)[-1]
                 if self._pattern in rid:
                     return True
 


### PR DESCRIPTION
We need to copy the spec file into the build directory for the rpm target to work correctly.