### PR TITLE
Fix build and Pylint pipeline

### DIFF
--- a/gnome-abrt.spec
+++ b/gnome-abrt.spec
@@ -23,7 +23,7 @@ Source0:    %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 %endif
 
 BuildRequires: git-core
-BuildRequires: meson
+BuildRequires: meson >= 0.59.0
 BuildRequires: gettext
 BuildRequires: libtool
 BuildRequires: python3-devel

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,8 @@ mandir = get_option('mandir')
 pkgdatadir = join_paths(datadir, meson.project_name())
 prefix = get_option('prefix')
 
+spec_name = '@0@.spec'.format(meson.project_name())
+
 gnome = import('gnome')
 i18n = import('i18n')
 python = import('python')
@@ -50,6 +52,14 @@ subdir('doc')
 subdir('icons')
 subdir('po')
 subdir('src')
+
+# Copy the spec file to the build directory so that Tito can run inside it to build
+# the rpm and srpm targets (below).
+configure_file(
+  copy: true,
+  input: spec_name,
+  output: spec_name,
+)
 
 # This will, naturally, fail if the build directory is outside the git repo,
 # since Tito does not provide a way to specify the working directory or the spec

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('gnome-abrt', 'c', meson_version : '>= 0.51.0', license : 'GPL3+', version : '1.4.1')
+project('gnome-abrt', 'c', meson_version : '>= 0.59.0', license : 'GPL3+', version : '1.4.1')
 
 bindir = get_option('bindir')
 datadir = get_option('datadir')

--- a/src/gnome_abrt/l10n.py
+++ b/src/gnome_abrt/l10n.py
@@ -43,8 +43,6 @@ def init(progname, localedir='/usr/share/locale'):
     except IOError as ex:
         logging.debug("Unsupported locale '%s': %s", lcl, str(ex))
 
-    gettext.bind_textdomain_codeset(progname,
-                                    locale.nl_langinfo(locale.CODESET))
     gettext.bindtextdomain(progname, localedir)
     gettext.textdomain(progname)
 

--- a/src/gnome_abrt/problems.py
+++ b/src/gnome_abrt/problems.py
@@ -125,8 +125,8 @@ class Problem:
 
                 def update_title_task_func(task, source_object, task_data, cancellable):
                     try:
-                        req = urllib.request.urlopen(self._data)
-                        html = req.read().decode("UTF-8")
+                        with urllib.request.urlopen(self._data) as req:
+                            html = req.read().decode("UTF-8")
                         soup = BeautifulSoup(html, "html.parser")
                         value = GObject.Value(str, soup.title.string)
 

--- a/src/gnome_abrt/views.py
+++ b/src/gnome_abrt/views.py
@@ -93,8 +93,8 @@ class ProblemsFilter:
 
                 # _pattern is 'str' and sbm.data is 'dbus.String', so we need
                 # to convert sbm.data to a regular 'str'
-                rid = str(sbm.data)
-                rid = rid.rstrip('/').split('/')[-1].split('=')[-1]
+                rid = str(sbm.data).rstrip('/')
+                rid = rid.rsplit('/', maxsplit=1)[-1].rsplit('=', maxsplit=1)[-1]
                 if self._pattern in rid:
                     return True
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -27,6 +27,9 @@ gnome_abrt_main = configure_file(
 subdir('gnome_abrt')
 
 if pylint.found()
+  lint_env = environment({
+    'GDK_BACKEND': '-',
+  })
   test('lint', pylint,
     args: [
       # This will not fail during configuration if pylintrc is missing:
@@ -35,10 +38,11 @@ if pylint.found()
       'gnome-abrt',
       'gnome_abrt',
     ],
-    workdir: meson.current_build_dir(),
     depends: [
       gnome_abrt_wrappers_module,
     ],
+    env: lint_env,
     timeout: 180, # 3 minutes
+    workdir: meson.current_build_dir(),
   )
 endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,7 +3,7 @@ i18n.merge_file(
   install: true,
   install_dir: join_paths(datadir, 'metainfo'),
   output: 'org.freedesktop.GnomeAbrt.appdata.xml',
-  po_dir: join_paths(meson.source_root(), 'po'),
+  po_dir: join_paths(meson.project_source_root(), 'po'),
   type: 'xml'
 )
 
@@ -12,7 +12,7 @@ i18n.merge_file(
   install: true,
   install_dir: join_paths(datadir, 'applications'),
   output: 'org.freedesktop.GnomeAbrt.desktop',
-  po_dir: join_paths(meson.source_root(), 'po'),
+  po_dir: join_paths(meson.project_source_root(), 'po'),
   type: 'desktop'
 )
 
@@ -31,7 +31,7 @@ if pylint.found()
     args: [
       # This will not fail during configuration if pylintrc is missing:
       # https://github.com/mesonbuild/meson/issues/6175
-      '--rcfile=@0@'.format(join_paths(meson.source_root(), 'pylintrc')),
+      '--rcfile=@0@'.format(join_paths(meson.project_source_root(), 'pylintrc')),
       'gnome-abrt',
       'gnome_abrt',
     ],

--- a/src/meson.build
+++ b/src/meson.build
@@ -35,6 +35,7 @@ if pylint.found()
       # This will not fail during configuration if pylintrc is missing:
       # https://github.com/mesonbuild/meson/issues/6175
       '--rcfile=@0@'.format(join_paths(meson.project_source_root(), 'pylintrc')),
+      '--limit-inference-results=5',
       'gnome-abrt',
       'gnome_abrt',
     ],


### PR DESCRIPTION
Make sure the spec file is in the build directory so that Tito can run the `rpm` and `srpm` targets.