### PR TITLE
Update copyright year

### DIFF
--- a/src/gnome-abrt
+++ b/src/gnome-abrt
@@ -246,7 +246,7 @@ class OopsApplication(Gtk.Application):
         dialog.set_version(gnome_abrt.VERSION)
         dialog.set_logo_icon_name(GNOME_ABRT_APPLICATION_ID)
         dialog.set_program_name(_("Problem Reporting"))
-        dialog.set_copyright("Copyright © 2019 Red Hat, Inc")
+        dialog.set_copyright("Copyright © 2024 Red Hat, Inc")
         dialog.set_license(
     "This program is free software; you can redistribut"
     "e it and/or modify it under the terms of the GNU General Public License "


### PR DESCRIPTION
Updated the copyright year from 2019 to 2024.
This is visible under `three dots in top right` > `About Problem Reporting`.

![image](https://github.com/abrt/gnome-abrt/assets/50550545/3325275f-f7e0-460f-ae6b-5076a5337d97)
