### PR TITLE
data: Replace X-GNOME-Utilities category with generic Utility

### DIFF
--- a/src/org.freedesktop.GnomeAbrt.desktop.in
+++ b/src/org.freedesktop.GnomeAbrt.desktop.in
@@ -7,6 +7,6 @@ Icon=org.freedesktop.GnomeAbrt
 Exec=gnome-abrt
 Terminal=false
 Type=Application
-Categories=System;X-GNOME-Utilities;
+Categories=System;Utility;
 StartupNotify=true
 X-Desktop-File-Install-Version=0.15


### PR DESCRIPTION
The X-GNOME-Utilities category is being removed from gnome-shell and a curated [app list](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/appDisplay.js?ref_type=heads#L62) should be used instead.