### PR TITLE
Make window title translatable

### DIFF
--- a/data/ui/oops-window.ui
+++ b/data/ui/oops-window.ui
@@ -3,7 +3,7 @@
   <template class="OopsWindow" parent="GtkApplicationWindow">
     <property name="default-width">1100</property>
     <property name="default-height">768</property>
-    <property name="title">Problem Reporting</property>
+    <property name="title" translatable="yes">Problem Reporting</property>
     <requires lib="gtk" version="4.0"/>
     <requires lib="adwaita" version="1.0"/>
     <child type="titlebar">


### PR DESCRIPTION
Not sure why this was removed during the gtk4 port, but the window title should definitely be translatable.

/cc @msrb